### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.2)
+    mimemagic (0.3.7)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)


### PR DESCRIPTION
Your bundle is locked to mimemagic (0.3.2) from rubygems repository https://rubygems.org/ or installed locally, but that version can no longer be found in that source. That means the author of mimemagic (0.3.2) has removed it